### PR TITLE
Fix deploy job condition in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
   # New deploy job
   deploy:
     needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master' # This is the new line
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- remove stray comment from the deploy job `if:` condition

## Testing
- `stack --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684059cfae348322944c54b25d45b785